### PR TITLE
Add Xerox Publishing Standards

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,9 @@ If you have used any of these styleguides, please add a comment if you can! The 
 * [Styleguides.io](https://github.com/maban/styleguides)
 * [UI Styleguides](http://kevinwuhoo.github.io/ui-styleguides)
 
+#### Historical
+* [Xerox Publishing Standards](https://archive.org/details/xeroxpublishingstan00xero) - the definitive reference to writing style and design for the business world. Provided courtesy of Xerox Corporation.
+
 # Styleguides
 
 ## Generic


### PR DESCRIPTION
Description adapted from http://www.janvwhite.org/xerox-publishing-standards (might be a better link, because it also includes the Internet Archive links).

I've put it under an **Historical** section because it's from 1988. It has tons of good advice for writing, and people might find it interesting.

Most of the styleguides listed on `awesome-styleguides` are for programming languages, so maybe place can be made for general ones like this?
